### PR TITLE
Fixed addEvent connection with backend

### DIFF
--- a/actions/actions.js
+++ b/actions/actions.js
@@ -42,7 +42,7 @@ export const addEvent = (event, username, creator) => {
         console.log('Data from addevent fetch', data);
         dispatch({
           type: types.ADD_EVENT,
-          payload: data.events[data.events.length - 1],
+          payload: data,
         });
       });
   };

--- a/actions/actions.js
+++ b/actions/actions.js
@@ -42,7 +42,7 @@ export const addEvent = (event, username, creator) => {
         console.log('Data from addevent fetch', data);
         dispatch({
           type: types.ADD_EVENT,
-          payload: data,
+          payload: data.addedEvent,
         });
       });
   };

--- a/reducers/unBucketReducer.js
+++ b/reducers/unBucketReducer.js
@@ -27,17 +27,10 @@ const unBucketReducer = (state = initialState, action) => {
       };
 
     case types.ADD_EVENT:
-      const {
-        event_id,
-        event_name,
-        description,
-        location,
-        date,
-        guests,
-      } = action.payload;
+      const { _id, name, description, location, date, guests } = action.payload;
       const newEvent = {
-        event_id,
-        event_name,
+        event_id: _id,
+        event_name: name,
         description,
         location,
         date,

--- a/screens/AddEvent.js
+++ b/screens/AddEvent.js
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const AddEvent = (props) => {
   let event_name, description, location, date, guests;
-
+  console.log('Date is', date);
   const handleAddEvent = () => {
     const event = {
       event_name,

--- a/screens/AddEvent.js
+++ b/screens/AddEvent.js
@@ -24,8 +24,14 @@ const mapDispatchToProps = (dispatch) => ({
 
 const AddEvent = (props) => {
   let event_name, description, location, date, guests;
-  console.log('Date is', date);
+
   const handleAddEvent = () => {
+    if (!event_name || !description) {
+      alert('You must set an event name and description');
+      return;
+    } else if (!date) {
+      date = null;
+    }
     const event = {
       event_name,
       description,

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -30,7 +30,7 @@ const Home = (props) => {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text>Welcome {props.username}!</Text>
+        <Text>Welcome {props.creator}!</Text>
         <Text>Here is your unBucket List</Text>
       </View>
       <View style={styles.eventContainer}>{eventList}</View>


### PR DESCRIPTION
Adding an event will now work with back end communication. It will update home screen with new event. Add event will not work without an event name, creator, or description and those are sent with the request from client-side to server-side.